### PR TITLE
remove uptimed

### DIFF
--- a/hosts/mycroft/default.nix
+++ b/hosts/mycroft/default.nix
@@ -8,7 +8,6 @@
     ../../services/openssh.nix
     ../../services/postfix
     ../../services/smartd.nix
-    ../../services/uptimed.nix
     #../../system.nix
     ../../users/alunduil.nix
   ];

--- a/services/uptimed.nix
+++ b/services/uptimed.nix
@@ -1,8 +1,0 @@
-{ pkgs, ... }:
-{
-  environment.systemPackages = [
-    pkgs.uptimed
-  ];
-
-  services.uptimed.enable = true;
-}

--- a/system.nix
+++ b/system.nix
@@ -3,7 +3,6 @@
   imports = [
     ./services/datadog.nix
     ./services/smartd.nix
-    ./services/uptimed.nix
     ./users/alunduil.nix
   ];
 


### PR DESCRIPTION
The uptimed service on nixos has never persisted correctly across
reboots.