### PR TITLE
Separate minikube into a module.

### DIFF
--- a/profiles/laptop/default.nix
+++ b/profiles/laptop/default.nix
@@ -4,10 +4,10 @@
     ./chromecast.nix
     ./cifs
     ./libvirtd.nix
-    ../../services/postfix
+    ./minikube.nix
     ./pulseaudio.nix
     ./redshift.nix
-    ../../services/docker.nix
+    ../../services/postfix
     ./slock.nix
     ../../system.nix
     ./tmux.nix
@@ -23,8 +23,6 @@
     pkgs.alacritty
     pkgs.google-chrome
     pkgs.gource
-    pkgs.kubectl
-    pkgs.minikube
     pkgs.python36Packages.goobook
   ];
 

--- a/profiles/laptop/minikube.nix
+++ b/profiles/laptop/minikube.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+{
+  imports = [
+    ../../services/docker.nix
+  ];
+
+  environment.systemPackages = [
+    pkgs.docker-machine
+    pkgs.docker-machine-kvm
+    pkgs.docker-machine-kvm2
+    pkgs.kubectl
+    pkgs.minikube
+  ];
+}


### PR DESCRIPTION
I also drop the direct dependency on the docker service with this diff.