### PR TITLE
Specify the system.stateVersion on each host.

### DIFF
--- a/hosts/odin.nix
+++ b/hosts/odin.nix
@@ -10,6 +10,7 @@
   };
 
   services.postfix.hostname = pkgs.lib.mkForce "odin.laptops.alunduil.com";
+  system.stateVersion = "19.09";
 
   time.timeZone = "America/Los_Angeles";
 }


### PR DESCRIPTION
It turns out that during an upgrade to a new version of NixOS the best
practice is to change the stateVersion after everything is verified as
working and to ensure that any transition items are run correctly.