### PR TITLE
Remove fcron.

### DIFF
--- a/system.nix
+++ b/system.nix
@@ -67,11 +67,7 @@
     sudo.wheelNeedsPassword = false;
   };
 
-  services = {
-    acpid.enable = true;
-    cron.enable = false;
-    fcron.enable = true;
-  };
+  services.acpid.enable = true;
 
   system.autoUpgrade.enable = true;
 }

--- a/users/alunduil.nix
+++ b/users/alunduil.nix
@@ -6,7 +6,6 @@
       extraGroups = [
         "audio"
         "docker"
-        "fcron"
         "libvirtd"
         "networkmanager"
         "systemd-journal"


### PR DESCRIPTION
Now that I'm using systemd timers exclusively, I no longer need an
improved and configurable cron system.