### PR TITLE
Ensure md4 is loaded for cifs.

### DIFF
--- a/profiles/laptop/cifs/default.nix
+++ b/profiles/laptop/cifs/default.nix
@@ -1,5 +1,7 @@
 { pkgs, ... }:
 {
+  boot.kernelModules = [ "md4" ];
+
   environment.etc = {
     "cifs.credentials" = {
       mode = "0600";


### PR DESCRIPTION
For some reason the md4 module no longer loads (I thought I had disabled
dynamic loading of modules but couldn't find it quickly to confirm).
This ensures that md4 is loaded so that CIFS functions correctly during
authorization.  For some reason CIFS still uses md4 during authorization
even though a modern authentication protocal is chosen and a modern SMB
protocal is used.