### PR TITLE
Load veth on startup in docker module.

### DIFF
--- a/services/docker.nix
+++ b/services/docker.nix
@@ -1,5 +1,7 @@
 { ... }:
 {
+  boot.kernelModules = [ "veth" ];
+
   virtualisation.docker = {
     autoPrune.enable = true;
     enable = true;


### PR DESCRIPTION
Docker requires the veth module to setup networking.  This ensures the
module is listed as part of the startup loading of modules.