### PR TITLE
Disable kernel module locking.

### DIFF
--- a/system.nix
+++ b/system.nix
@@ -73,6 +73,7 @@
       ];
     };
     auditd.enable = true;
+    lockKernelModules = false;
     sudo.wheelNeedsPassword = false;
   };
 


### PR DESCRIPTION
Turns out that any encrypted WiFi connection on recent kernels requires
a module that doesn't get loaded during startup.  I'm still not sure of
which one so this will do for now.