### PR TITLE
Rmove hardened profile from system configuration.

### DIFF
--- a/system.nix
+++ b/system.nix
@@ -1,7 +1,6 @@
 { config, pkgs, ... }:
 {
   imports = [
-    <nixpkgs/nixos/modules/profiles/hardened.nix>
     ./services/smartd.nix
     ./users/alunduil.nix
   ];


### PR DESCRIPTION
Apparently the hardened profile is not for general consumption and leads
to issues most insidious at times.  The worst bit was losing all boot
loader entries and then rebooting.  See
https://github.com/NixOS/nixpkgs/issues/102624 for full details.