### PR TITLE
Add printing configuration.

### DIFF
--- a/profiles/laptop/default.nix
+++ b/profiles/laptop/default.nix
@@ -1,15 +1,16 @@
 { config, pkgs, ... }:
 {
   imports = [
+    ../../services/postfix
+    ../../system.nix
     ./chromecast.nix
     ./cifs
     ./libvirtd.nix
     ./minikube.nix
+    ./printing.nix
     ./pulseaudio.nix
     ./redshift.nix
-    ../../services/postfix
     ./slock.nix
-    ../../system.nix
     ./tmux.nix
     ./udiskie.nix
     ./unclutter.nix

--- a/profiles/laptop/printing.nix
+++ b/profiles/laptop/printing.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+{
+  services.printing = {
+    enable = true;
+    drivers = [ pkgs.hplipWithPlugin ];
+  };
+}


### PR DESCRIPTION
Without google cloud print being available anymore, it looks like we
need to configure printing directly.